### PR TITLE
Fix atomic names

### DIFF
--- a/flloat/flloat.py
+++ b/flloat/flloat.py
@@ -31,8 +31,10 @@ def find_atomics(formula: Formula) -> Set[PLAtomic]:
     res = set()
     if isinstance(formula, PLFormula):
         res = formula.find_atomics()
+    elif isinstance(formula, PLAtomic):
+        res.add(formula)
     else:
-        res.add(PLAtomic(formula))
+        raise TypeError("Logic error: unexpected type.")
     return res
 
 

--- a/flloat/ldlf.py
+++ b/flloat/ldlf.py
@@ -16,11 +16,12 @@ from flloat.base import (
     RegExpTruth,
     AtomicFormula,
     FiniteTrace,
+    AtomSymbol,
 )
 from flloat.delta import Delta
 from flloat.flloat import to_automaton
 from flloat.pl import PLFormula, PLTrue, PLFalse, PLAnd, PLOr, PLAtomic
-from flloat.symbols import Symbol, Symbols
+from flloat.symbols import Symbols, OpSymbol
 
 
 class LDLfFormula(Formula, FiniteTraceTruth, Delta, ABC):
@@ -141,7 +142,7 @@ class LDLfTemporalFormula(LDLfFormula, ABC):
             + ")"
         )
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return self.f.find_labels().union(self.r.find_labels())
 
@@ -156,7 +157,7 @@ class LDLfPropositionalAtom(LDLfFormula):
     In LDLf with empty trace, this is equivalent to <phi>tt.
     """
 
-    def __init__(self, s: Symbol):
+    def __init__(self, s: AtomSymbol):
         """Initialize the formula."""
         super().__init__()
         self.s = s
@@ -180,7 +181,7 @@ class LDLfPropositionalAtom(LDLfFormula):
         """Negate the formula."""
         return self.to_nnf().negate()
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return {self.s}
 
@@ -254,7 +255,7 @@ class LDLfNot(UnaryOperator, LDLfFormula):
         self.f = cast(LDLfFormula, self.f)
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.NOT.value
 
@@ -291,7 +292,7 @@ class LDLfAnd(LDLfBinaryOperator):
     """Class for the LDLf And formulas."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.AND.value
 
@@ -312,7 +313,7 @@ class LDLfOr(LDLfBinaryOperator):
     """Class for the LDLf Or formulas."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.OR.value
 
@@ -333,7 +334,7 @@ class LDLfImplies(LDLfBinaryOperator):
     """Class for the LDLf Implication formulas."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.IMPLIES.value
 
@@ -364,7 +365,7 @@ class LDLfEquivalence(LDLfBinaryOperator):
     """Class for the LDLf Equivalence formulas."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.EQUIVALENCE.value
 
@@ -504,7 +505,7 @@ class RegExpTest(UnaryOperator, RegExpFormula):
         self.f = cast(LDLfFormula, self.f)
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.PATH_TEST.value
 
@@ -550,7 +551,7 @@ class RegExpUnion(BinaryOperator, RegExpFormula):
         self.formulas = cast(Sequence[RegExpFormula], self.formulas)
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.PATH_UNION.value
 
@@ -577,7 +578,7 @@ class RegExpSequence(BinaryOperator, RegExpFormula):
     """Class for the sequence regex."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.PATH_SEQUENCE.value
 
@@ -624,7 +625,7 @@ class RegExpStar(UnaryOperator, RegExpFormula):
     """Class for the star regex."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.PATH_STAR.value
 
@@ -680,7 +681,7 @@ class LDLfEnd(LDLfFormula):
         """Apply the delta function."""
         return self.to_nnf()._delta(i, epsilon=epsilon)
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return self.to_nnf().find_labels()
 
@@ -711,7 +712,7 @@ class LDLfLast(LDLfFormula):
         """Apply the delta function."""
         return self.to_nnf()._delta(i, epsilon=epsilon)
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return self.to_nnf().find_labels()
 

--- a/flloat/ltlf.py
+++ b/flloat/ltlf.py
@@ -85,20 +85,7 @@ class LTLfBinaryOperator(BinaryOperator[LTLfFormula], LTLfFormula, ABC):
 class LTLfAtomic(AtomicFormula, LTLfFormula):
     """Class for LTLf atomic formulas."""
 
-    symbol_string = re.compile("[a-z][a-z0-9_]*")
-
-    def __init__(self, s: AtomSymbol):
-        """
-        Inintializes the a propositional symbol.
-
-        :param s: the symbol name must be composed of lower-case letters,
-            numbers and lowercases, starting with a letter.
-        """
-        if not self.symbol_string.fullmatch(str(s)):
-            raise ValueError(
-                "The symbol name does not respect the convention. See doc."
-            )
-        AtomicFormula.__init__(self, s)
+    name_regex = re.compile(r"[a-z][a-z0-9_]*")
 
     def negate(self):
         """Negate the formula."""

--- a/flloat/ltlf.py
+++ b/flloat/ltlf.py
@@ -23,11 +23,12 @@ from flloat.base import (
     FiniteTrace,
     UnaryOperator,
     BinaryOperator,
+    AtomSymbol,
 )
 from flloat.delta import Delta
 from flloat.flloat import to_automaton
 from flloat.pl import PLFalse, PLTrue, PLAtomic, PLOr, PLAnd, PLFormula
-from flloat.symbols import Symbol, Symbols
+from flloat.symbols import Symbols, OpSymbol
 
 
 class LTLfFormula(Formula, FiniteTraceTruth, Delta, ABC):
@@ -86,7 +87,7 @@ class LTLfAtomic(AtomicFormula, LTLfFormula):
 
     symbol_string = re.compile("[a-z][a-z0-9_]*")
 
-    def __init__(self, s: Symbol):
+    def __init__(self, s: AtomSymbol):
         """
         Inintializes the a propositional symbol.
 
@@ -116,7 +117,7 @@ class LTLfAtomic(AtomicFormula, LTLfFormula):
         else:
             return False
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return PLAtomic(self.s).find_labels()
 
@@ -146,7 +147,7 @@ class LTLfTrue(LTLfAtomic):
         """Negate the formula."""
         return LTLfFalse()
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return set()
 
@@ -170,7 +171,7 @@ class LTLfFalse(LTLfAtomic):
         """Evaluate the formula."""
         return False
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return set()
 
@@ -179,7 +180,7 @@ class LTLfNot(LTLfUnaryOperator):
     """Class for the LTLf not formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.NOT.value
 
@@ -223,7 +224,7 @@ class LTLfAnd(LTLfBinaryOperator):
     """Class for the LTLf And formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.AND.value
 
@@ -251,7 +252,7 @@ class LTLfOr(LTLfBinaryOperator):
     """Class for the LTLf Or formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.OR.value
 
@@ -276,7 +277,7 @@ class LTLfImplies(LTLfBinaryOperator):
     """Class for the LTLf Implication formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.IMPLIES.value
 
@@ -307,7 +308,7 @@ class LTLfEquivalence(LTLfBinaryOperator):
     """Class for the LTLf Equivalente formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.EQUIVALENCE.value
 
@@ -336,7 +337,7 @@ class LTLfNext(LTLfUnaryOperator):
     """Class for the LTLf Next formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.NEXT.value
 
@@ -370,7 +371,7 @@ class LTLfWeakNext(LTLfUnaryOperator):
     """Class for the LTLf Weak Next formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.WEAK_NEXT.value
 
@@ -401,7 +402,7 @@ class LTLfUntil(LTLfBinaryOperator):
     """Class for the LTLf Until formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.UNTIL.value
 
@@ -457,7 +458,7 @@ class LTLfRelease(LTLfBinaryOperator):
     """Class for the LTLf Release formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.RELEASE.value
 
@@ -504,7 +505,7 @@ class LTLfEventually(LTLfUnaryOperator):
     """Class for the LTLf Eventually formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.EVENTUALLY.value
 
@@ -535,7 +536,7 @@ class LTLfAlways(LTLfUnaryOperator):
     """Class for the LTLf Always formula."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.ALWAYS.value
 
@@ -563,7 +564,7 @@ class LTLfEnd(LTLfFormula):
         """Apply the delta function."""
         return self.to_nnf()._delta(i, epsilon=epsilon)
 
-    def find_labels(self) -> Set[Symbol]:
+    def find_labels(self) -> Set[AtomSymbol]:
         """Find the labels."""
         return self.to_nnf().find_labels()
 

--- a/flloat/pl.py
+++ b/flloat/pl.py
@@ -19,8 +19,9 @@ from flloat.base import (
     AtomicFormula,
     BinaryOperator,
     UnaryOperator,
+    AtomSymbol,
 )
-from flloat.symbols import Symbol, Symbols
+from flloat.symbols import Symbols, OpSymbol
 
 
 class PLFormula(Formula, PropositionalTruth):
@@ -57,7 +58,7 @@ class PLFormula(Formula, PropositionalTruth):
 
 
 def to_sympy(
-    formula: Formula, replace: Optional[Dict[Symbol, sympy.Symbol]] = None
+    formula: Formula, replace: Optional[Dict[AtomSymbol, sympy.Symbol]] = None
 ) -> Boolean:
     """
     Translate a PLFormula object into a SymPy expression.
@@ -182,7 +183,7 @@ class PLNot(UnaryOperator[PLFormula], PLFormula):
     """Propositional Not."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.NOT.value
 
@@ -209,7 +210,7 @@ class PLOr(PLBinaryOperator):
     """Propositional Or."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.OR.value
 
@@ -230,7 +231,7 @@ class PLAnd(PLBinaryOperator):
     """Propositional And."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.AND.value
 
@@ -251,7 +252,7 @@ class PLImplies(PLBinaryOperator):
     """Propositional Implication."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.IMPLIES.value
 
@@ -276,7 +277,7 @@ class PLEquivalence(PLBinaryOperator):
     """Propositional Equivalence."""
 
     @property
-    def operator_symbol(self) -> Symbol:
+    def operator_symbol(self) -> OpSymbol:
         """Get the operator symbol."""
         return Symbols.EQUIVALENCE.value
 

--- a/flloat/symbols.py
+++ b/flloat/symbols.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """This module contains the definition to deal with symbols."""
 from enum import Enum
-from typing import Set, Hashable
+from typing import Set
 
-Symbol = Hashable
+
+OpSymbol = str
 
 
 class Symbols(Enum):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -70,3 +70,18 @@ def test_hash_consistency_after_pickling():
     assert h == hash(new_obj)
 
     os.remove("temp")
+
+
+def test_QuotedFormula():
+    from flloat.parser.ltlf import LTLfParser
+    from flloat.base import QuotedFormula
+
+    f = LTLfParser()("!(G a & X b)")
+    qf = QuotedFormula(f)
+
+    assert qf.wrapped is f
+
+    dir_qf = dir(qf)
+    for member in dir(f):
+        assert member in dir_qf
+        assert hasattr(qf, member)

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -174,6 +174,27 @@ def test_find_labels():
     assert formula.find_labels() == {c for c in {"A", "AB", "A0"}}
 
 
+def test_names():
+
+    good = [
+        "A",
+        "b",
+        "Hello",
+        "PropZero",
+        "Prop0",
+        "this_is_fine_2",
+        '"This is also allowed!"',
+        PLParser()("A -> B"),
+    ]
+    bad = ["!", "&", "Invalid:", "", '"', "="]
+
+    for name in good:
+        PLAtomic(name)
+    for name in bad:
+        with pytest.raises(ValueError):
+            PLAtomic(name)
+
+
 class TestParsingTree:
     """\
     The parsing tree should give the right priority to the operators.


### PR DESCRIPTION
## Proposed changes

- More strict type checking: the generic `Symbol` type is now substituted by the more specific `AtomSymbol`, for propositional symbols, and `OpSymbol` for operator symbols.
- Any `AtomicFormula.s` stores a symbol of type `AtomSymbol`. This can be a propositional name, or a quoted formula. Any name must respect a naming convention.
- A `QuotedFormula` is a freezed view of any `Formula`. This is an Hashable object.

## Fixes

Fixes #13 , addresses comments in #18 .

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
