### PR TITLE
Add tests on the equivalence between the formula and its negative normal form.

### DIFF
--- a/tests/test_ldlf.py
+++ b/tests/test_ldlf.py
@@ -297,13 +297,27 @@ class TestToAutomaton:
 
 
 @pytest.fixture(scope="session", params=ldlf_formulas)
-def formula_automa_pair(request):
+def ldlf_formula_automa_pair(request):
     formula_obj = parser(request.param)
     automaton = formula_obj.to_automaton()
     return formula_obj, automaton
 
 
-@given(propositional_words(["A", "B", "C"], min_size=0, max_size=5))
-def test_formula_automaton_equivalence(formula_automa_pair, word):
-    formula_obj, automaton = formula_automa_pair
+@pytest.fixture(scope="session", params=ldlf_formulas)
+def ldlf_formula_nnf_pair(request):
+    formula_obj = parser(request.param)
+    nnf = formula_obj.to_nnf()
+    return formula_obj, nnf
+
+
+@given(propositional_words(["a", "b", "c"], min_size=0, max_size=5))
+def test_nnf_equivalence(ldlf_formula_nnf_pair, word):
+    """Test that a formula is equivalent to its NNF form."""
+    formula, formula_nnf = ldlf_formula_nnf_pair
+    assert formula.truth(word, 0) == formula_nnf.truth(word, 0)
+
+
+@given(propositional_words(["a", "b", "c"], min_size=0, max_size=5))
+def test_formula_automaton_equivalence(ldlf_formula_automa_pair, word):
+    formula_obj, automaton = ldlf_formula_automa_pair
     assert formula_obj.truth(word, 0) == automaton.accepts(word)

--- a/tests/test_ltlf.py
+++ b/tests/test_ltlf.py
@@ -726,15 +726,29 @@ class TestToAutomaton:
 
 
 @pytest.fixture(scope="session", params=ltlf_formulas)
-def formula_automa_pair(request):
+def ltlf_formula_automa_pair(request):
     formula_obj = parser(request.param)
     automaton = formula_obj.to_automaton()
     return formula_obj, automaton
 
 
+@pytest.fixture(scope="session", params=ltlf_formulas)
+def ltlf_formula_nnf_pair(request):
+    formula_obj = parser(request.param)
+    nnf = formula_obj.to_nnf()
+    return formula_obj, nnf
+
+
 @given(propositional_words(["a", "b", "c"], min_size=0, max_size=5))
-def test_formula_automaton_equivalence(formula_automa_pair, word):
-    formula_obj, automaton = formula_automa_pair
+def test_nnf_equivalence(ltlf_formula_nnf_pair, word):
+    """Test that a formula is equivalent to its NNF form."""
+    formula, formula_nnf = ltlf_formula_nnf_pair
+    assert formula.truth(word, 0) == formula_nnf.truth(word, 0)
+
+
+@given(propositional_words(["a", "b", "c"], min_size=0, max_size=5))
+def test_formula_automaton_equivalence(ltlf_formula_automa_pair, word):
+    formula_obj, automaton = ltlf_formula_automa_pair
     assert formula_obj.truth(word, 0) == automaton.accepts(word)
 
 


### PR DESCRIPTION
## Proposed changes

This PR adds tests on the equivalence between the semantics of a formula and its negative normal form.

It uses Hypothesis to determine the equivalence, by generating random traces.

## Fixes

N/A

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments

N/A