### PR TITLE
Ldl parsing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,6 @@
 
 ## Contributors
 
-None yet. [Why not be the first](./contributing.md)? 
+* [Roberto Cipollone](https://github.com/cipollone) <[cipollone.rt@gmail.com](mailto:cipollone.rt@gmail.com)>
+
+[How to contribute](./CONTRIBUTING.md)? 

--- a/flloat/base.py
+++ b/flloat/base.py
@@ -8,7 +8,7 @@ import re
 from pythomata import PropositionalInterpretation
 
 from flloat.symbols import Symbols, OpSymbol
-from flloat.helpers import Hashable
+from flloat.helpers import Hashable, Wrapper
 
 FiniteTrace = Sequence[PropositionalInterpretation]
 AtomSymbol = Union["QuotedFormula", str]
@@ -72,59 +72,28 @@ class AtomicFormula(Formula, ABC):
         return {self.s}
 
 
-class QuotedFormula(Hashable):
+class QuotedFormula(Wrapper):
     """This object is a constant representation of a formula.
 
     This can be used as a normal formula. Quoted formulas can also be used as
     hashable objects and for atomic symbols.
     """
 
-    _mutable = ["_hash"]
-
     def __init__(self, f: Formula):
         """Initialize.
 
         :param f: formula to represent.
         """
-        super().__init__()
-        self.__dict__["_QuotedFormula__f"] = f
+        super().__init__(f)
         self.__dict__["_QuotedFormula__str"] = '"' + str(f) + '"'
 
-    def _members(self) -> Formula:
-        return self.__f
-
     def __str__(self):
-        """Quoted formula."""
+        """Cache str."""
         return self.__str
 
     def __repr__(self):
-        """Quoted formula."""
+        """Nice representation."""
         return str(self)
-
-    def __getattr__(self, attrname):
-        """Redirect to Formula."""
-        return getattr(self.__f, attrname)
-
-    def __setattr__(self, attr, value):
-        """If immutable, raises an error."""
-        if attr in self._mutable:
-            self.__dict__[attr] = value
-        else:
-            raise AttributeError("Can't modify: immutable object.")
-
-    def __delattr__(self, attr):
-        """Raise an error, because del is not supported."""
-        raise AttributeError("Can't modify: immutable object.")
-
-    def __dir__(self):
-        """Expose the same interface as wrapped."""
-        members = set(dir(self.__f)).union(object.__dir__(self))
-        return sorted(members)
-
-    @property
-    def wrapped(self) -> Formula:
-        """Return the wrapped Formula."""
-        return self.__f
 
 
 class Operator(Formula, ABC):
@@ -246,3 +215,29 @@ class RegExpTruth:
         :param end: the end index.
         :return: True if the regex is satisfied by the trace, False otherwise.
         """
+
+
+class FiniteTraceWrapper(Wrapper, FiniteTraceTruth):
+    """Valuate propositional sentences on finite traces.
+
+    This class wraps any propositional sentence, PropositionalTruth interface,
+    and exposes the FiniteTraceTruth interface.
+    """
+
+    def __init__(self, prop: PropositionalTruth):
+        """Wrap a propositional sentence."""
+        Wrapper.__init__(self, prop)
+
+    def truth(self, i: FiniteTrace, pos: int = 0) -> bool:
+        """Return the truth evaluation of a propositional on the trace.
+
+        In logics over finite traces, propositionals are used as descriptions
+        for a set of interpretations. Any propositional sentence (even `true`)
+        can only be satisfied in a valid instant of the trace: a proposition is
+        true if the current instant contains an interpretation which satisfy
+        the formula. Outside the trace everything is false.
+        """
+        if pos >= len(i):
+            return False
+        else:
+            return self.wrapped.truth(i[pos])

--- a/flloat/helpers.py
+++ b/flloat/helpers.py
@@ -53,6 +53,59 @@ class Hashable(ABC):
         self._hash = None
 
 
+class Wrapper(Hashable):
+    """Wrap other objects and expose the same interface.
+
+    This helper class can be subclassed to create a constant view on wrapped
+    objects, exposing the same interface.
+    This is an immutable object: either add members to _mutable list, or
+    modify them through __dict__.
+    """
+
+    _mutable = ["_hash"]
+
+    def __init__(self, obj):
+        """Initialize: save the wrapped object."""
+        super().__init__()
+        self.__dict__["_Wrapper__obj"] = obj
+
+    def __str__(self):
+        """Just forward to obj."""
+        return str(self.__obj)
+
+    def __repr__(self):
+        """Just forward to obj."""
+        return repr(self.__obj)
+
+    def __getattr__(self, attr):
+        """Redirect to obj."""
+        return getattr(self.__obj, attr)
+
+    def __setattr__(self, attr, value):
+        """If immutable, raises an error."""
+        if attr in self._mutable:
+            self.__dict__[attr] = value
+        else:
+            raise AttributeError("Can't modify: immutable object.")
+
+    def __delattr__(self, attr):
+        """Raise an error, because del is not supported."""
+        raise AttributeError("Can't modify: immutable object.")
+
+    def __dir__(self):
+        """Expose the same interface as wrapped."""
+        members = set(dir(self.__obj)).union(object.__dir__(self))
+        return sorted(members)
+
+    def _members(self):
+        return self.__obj
+
+    @property
+    def wrapped(self):
+        """Return the wrapped object."""
+        return self.__obj
+
+
 def powerset(s: Set) -> FrozenSet:
     """
     Compute the power set of a set.

--- a/flloat/parser/ldlf.lark
+++ b/flloat/parser/ldlf.lark
@@ -36,7 +36,7 @@ regular_expression: re_union
         |       re_wrapped
 ?re_wrapped:    re_propositional
            |    LSEPARATOR regular_expression RSEPARATOR
-?re_propositional: propositional_formula
+re_propositional: propositional_formula
 
 
 BOXLSEPARATOR: "["
@@ -52,8 +52,8 @@ FF.2: /(?i:ff)/
 
 %ignore /\s+/
 
-%import .pl.start -> propositional_formula
-%import .pl.prop_atom -> prop_atom
+%import .pl.propositional_formula
+%import .pl.prop_atom
 %import .pl.EQUIVALENCE -> EQUIVALENCE
 %import .pl.IMPLY -> IMPLY
 %import .pl.OR -> OR

--- a/flloat/parser/ldlf.lark
+++ b/flloat/parser/ldlf.lark
@@ -31,8 +31,7 @@ regular_expression: re_union
 ?re_union:      re_sequence (UNION re_sequence)*
 ?re_sequence:   re_star (SEQ re_star)*
 ?re_star:       re_test STAR?
-?re_test:       ldlf_box TEST
-        |       ldlf_diamond TEST
+?re_test:       TEST ldlf_formula
         |       re_wrapped
 ?re_wrapped:    re_propositional
            |    LSEPARATOR regular_expression RSEPARATOR

--- a/flloat/parser/ldlf.lark
+++ b/flloat/parser/ldlf.lark
@@ -1,56 +1,57 @@
 start: ldlf_formula
-ldlf_formula:  ldlf_equivalence
 
-ldlf_equivalence: ldlf_implication (EQUIVALENCE ldlf_implication)*
-ldlf_implication: ldlf_or (IMPLY ldlf_or)*
-ldlf_or: ldlf_and (OR ldlf_and)*
-ldlf_and: ldlf_box (AND ldlf_box)*
-ldlf_box: BOXLSEPARATOR regular_expression BOXRSEPARATOR ldlf_box
-        | ldlf_diamond
-ldlf_diamond: DIAMONDLSEPARATOR regular_expression DIAMONDRSEPARATOR ldlf_box
-            | ldlf_not
-ldlf_not: NOT* ldlf_atom
-ldlf_atom:   ldlf_tt
-           | ldlf_ff
-           | ldlf_last
-           | ldlf_end
-           | ldlf_wrapped
-ldlf_wrapped: LSEPARATOR ldlf_formula RSEPARATOR
+?ldlf_formula:  ldlf_equivalence
+?ldlf_equivalence: ldlf_implication (EQUIVALENCE ldlf_implication)*
+?ldlf_implication: ldlf_or (IMPLY ldlf_or)*
+?ldlf_or: ldlf_and (OR ldlf_and)*
+?ldlf_and: ldlf_unaryop (AND ldlf_unaryop)*
 
-ldlf_tt.2: TT
-ldlf_ff.2: FF
-ldlf_last.2: LAST
-ldlf_end.2: END
+?ldlf_unaryop:     ldlf_box
+             |     ldlf_diamond
+             |     ldlf_not
+             |     ldlf_wrapped
+?ldlf_box: BOXLSEPARATOR regular_expression BOXRSEPARATOR ldlf_unaryop
+?ldlf_diamond: DIAMONDLSEPARATOR regular_expression DIAMONDRSEPARATOR ldlf_unaryop
+?ldlf_not: NOT ldlf_unaryop
+?ldlf_wrapped:    ldlf_atom
+             |    LSEPARATOR ldlf_formula RSEPARATOR
+?ldlf_atom:   ldlf_tt
+          |   ldlf_ff
+          |   ldlf_last
+          |   ldlf_end
+          |   prop_atom
 
-regular_expression: regular_expression_union
+ldlf_tt: TT
+ldlf_ff: FF
+ldlf_last: LAST
+ldlf_end: END
 
-regular_expression_union: regular_expression_sequence (UNION regular_expression_sequence)*
-regular_expression_sequence: regular_expression_star (SEQ regular_expression_star)*
-regular_expression_star: regular_expression_test STAR?
-                       | LSEPARATOR regular_expression RSEPARATOR STAR?
-regular_expression_test: regular_expression_propositional
-                       | ldlf_formula TEST
-                       | LSEPARATOR ldlf_formula RSEPARATOR TEST
-regular_expression_propositional: propositional_formula
+regular_expression: re_union
+
+?re_union:      re_sequence (UNION re_sequence)*
+?re_sequence:   re_star (SEQ re_star)*
+?re_star:       re_wrapped STAR?
+//?re_test:       ldlf_formula TEST | re_wrapped
+?re_wrapped:    re_propositional
+           |    LSEPARATOR regular_expression RSEPARATOR
+?re_propositional: propositional_formula
 
 
-%import common.ESCAPED_STRING
-WHITESPACE: (" " | "\n")+
 BOXLSEPARATOR: "["
 BOXRSEPARATOR: "]"
 DIAMONDLSEPARATOR: "<"
 DIAMONDRSEPARATOR: ">"
-TT: "tt"
-FF: "ff"
 UNION: "+"
 SEQ: ";"
 TEST: "?"
 STAR: "*"
-%ignore WHITESPACE
+TT.2: /(?i:tt)/
+FF.2: /(?i:ff)/
+
+%ignore /\s+/
+
 %import .pl.start -> propositional_formula
-%import .pl.STRING -> STRING
-%import .pl.prop_true -> prop_true
-%import .pl.prop_false -> prop_false
+%import .pl.prop_atom -> prop_atom
 %import .pl.EQUIVALENCE -> EQUIVALENCE
 %import .pl.IMPLY -> IMPLY
 %import .pl.OR -> OR

--- a/flloat/parser/ldlf.lark
+++ b/flloat/parser/ldlf.lark
@@ -30,8 +30,10 @@ regular_expression: re_union
 
 ?re_union:      re_sequence (UNION re_sequence)*
 ?re_sequence:   re_star (SEQ re_star)*
-?re_star:       re_wrapped STAR?
-//?re_test:       ldlf_formula TEST | re_wrapped
+?re_star:       re_test STAR?
+?re_test:       ldlf_box TEST
+        |       ldlf_diamond TEST
+        |       re_wrapped
 ?re_wrapped:    re_propositional
            |    LSEPARATOR regular_expression RSEPARATOR
 ?re_propositional: propositional_formula

--- a/flloat/parser/ldlf.py
+++ b/flloat/parser/ldlf.py
@@ -32,6 +32,7 @@ class LDLfTransformer(Transformer):
     def __init__(self):
         super().__init__()
         self._pl_transformer = PLTransformer()
+        self._pl_imported = ("prop_atom", "propositional_formula")
 
     def __starred_binaryop(self, args, formula_type):
         """Process a binary operator with repetitions.
@@ -43,7 +44,7 @@ class LDLfTransformer(Transformer):
             a list of arguments.
         :return: a Formula.
         """
-        
+
         if len(args) == 1:
             return args[0]
         elif (len(args) - 1) % 2 == 0:
@@ -139,7 +140,7 @@ class LDLfTransformer(Transformer):
         if len(args) == 1:
             return args[0]
         elif len(args) == 2:
-            formula, _ = args
+            _, formula = args
             return RegExpTest(formula)
         else:
             raise ParsingError
@@ -162,7 +163,7 @@ class LDLfTransformer(Transformer):
 
         if attr.startswith("pl__"):
             return getattr(self._pl_transformer, attr[4:])
-        elif attr == "prop_atom" or attr == "propositional_formula":
+        elif attr in self._pl_imported:
             return getattr(self._pl_transformer, attr)
         elif attr.isupper():
             raise AttributeError("Terminals should not be parsed")

--- a/flloat/parser/ldlf.py
+++ b/flloat/parser/ldlf.py
@@ -22,11 +22,9 @@ from flloat.ldlf import (
     RegExpPropositional,
     LDLfEnd,
     LDLfLast,
-    LDLfPropositionalAtom,
 )
 from flloat.parser import CUR_DIR
 from flloat.parser.pl import PLTransformer
-from flloat.base import FiniteTraceWrapper
 
 
 class LDLfTransformer(Transformer):
@@ -159,28 +157,15 @@ class LDLfTransformer(Transformer):
         assert len(args) == 1
         return RegExpPropositional(args[0])
 
-    def _adapt_prop_to_traces(self, attr, args):
-        """Parse and prepare propositionals for valuation over traces."""
-
-        parsed = getattr(self._pl_transformer, attr)(args)
-        return FiniteTraceWrapper(parsed)
-
     def __getattr__(self, attr: str):
         """Also parse propositional logic."""
 
-        # Prop logic internals: parse and return
         if attr.startswith("pl__"):
             return getattr(self._pl_transformer, attr[4:])
-
-        # Prop logic entry points: parse and adapt to traces
         elif attr in self._pl_imported:
-            return lambda args: self._adapt_prop_to_traces(attr, args)
-
-        # Parsing not required: catched by lark
+            return getattr(self._pl_transformer, attr)
         elif attr.isupper():
             raise AttributeError("Terminals should not be parsed")
-
-        # Grammar error
         else:
             raise ParseError("No transformation exists for rule", attr)
 

--- a/flloat/parser/ltlf.lark
+++ b/flloat/parser/ltlf.lark
@@ -28,7 +28,7 @@ start: ltlf_formula
           |        ltlf_last
           |        ltlf_end
 
-ltlf_symbol: SYMBOL_STRING
+ltlf_symbol: SYMBOL_NAME
 ltlf_true: prop_true
 ltlf_false: prop_false
 ltlf_last: LAST
@@ -45,11 +45,10 @@ END.2: /(?i:end)/
 LAST.2: /(?i:last)/
 
 // Symbols cannot contain uppercase letters, because these are reserved
-SYMBOL_STRING: /[a-z][a-z0-9_]*/
+SYMBOL_NAME: /[a-z][a-z0-9_]*/
 
 %ignore /\s+/
 
-%import .pl.STRING -> STRING
 %import .pl.prop_true -> prop_true
 %import .pl.prop_false -> prop_false
 %import .pl.NOT -> NOT

--- a/flloat/parser/pl.lark
+++ b/flloat/parser/pl.lark
@@ -1,6 +1,6 @@
 start: propositional_formula
 
-propositional_formula: prop_equivalence
+?propositional_formula: prop_equivalence
 ?prop_equivalence: prop_implication (EQUIVALENCE prop_implication)*
 ?prop_implication: prop_or (IMPLY prop_or)*
 ?prop_or: prop_and (OR prop_and)*
@@ -8,7 +8,7 @@ propositional_formula: prop_equivalence
 ?prop_not: NOT* prop_wrapped
 ?prop_wrapped: prop_atom
             | LSEPARATOR propositional_formula RSEPARATOR
-prop_atom: atom
+?prop_atom: atom
 	     | prop_true
 	     | prop_false
 

--- a/flloat/parser/pl.lark
+++ b/flloat/parser/pl.lark
@@ -13,8 +13,8 @@ start: propositional_formula
 	     | prop_false
 
 atom: SYMBOL_NAME
-prop_true.2: TRUE
-prop_false.2: FALSE
+prop_true: TRUE
+prop_false: FALSE
 
 LSEPARATOR : "("
 RSEPARATOR : ")"

--- a/flloat/parser/pl.lark
+++ b/flloat/parser/pl.lark
@@ -12,7 +12,7 @@ start: propositional_formula
 	     | prop_true
 	     | prop_false
 
-atom: STRING
+atom: SYMBOL_NAME
 prop_true.2: TRUE
 prop_false.2: FALSE
 
@@ -23,7 +23,7 @@ IMPLY : "->"
 OR: "||"|"|"
 AND: "&&"|"&"
 NOT: "!"
-STRING: /[a-zA-Z]\w*/
+SYMBOL_NAME: /(\w+)|(".*")/
 TRUE.2: /(?i:true)/
 FALSE.2: /(?i:false)/
 

--- a/flloat/parser/pl.lark
+++ b/flloat/parser/pl.lark
@@ -1,6 +1,6 @@
 start: propositional_formula
 
-?propositional_formula: prop_equivalence
+propositional_formula: prop_equivalence
 ?prop_equivalence: prop_implication (EQUIVALENCE prop_implication)*
 ?prop_implication: prop_or (IMPLY prop_or)*
 ?prop_or: prop_and (OR prop_and)*
@@ -8,7 +8,7 @@ start: propositional_formula
 ?prop_not: NOT* prop_wrapped
 ?prop_wrapped: prop_atom
             | LSEPARATOR propositional_formula RSEPARATOR
-?prop_atom: atom
+prop_atom: atom
 	     | prop_true
 	     | prop_false
 

--- a/flloat/pl.py
+++ b/flloat/pl.py
@@ -7,11 +7,8 @@ from abc import abstractmethod, ABC
 from typing import Set, Any, Dict, Optional
 
 import sympy
-from pythomata import (
-    PropositionalInterpretation as PropInt,
-    PropositionalInterpretation,
-)
 from sympy.logic.boolalg import Boolean, BooleanTrue, BooleanFalse
+from pythomata import PropositionalInterpretation
 
 from flloat.base import (
     Formula,
@@ -102,7 +99,7 @@ def to_sympy(
 class PLAtomic(AtomicFormula, PLFormula):
     """A class to represent propositional atomic formulas."""
 
-    def truth(self, i: PropInt, *args):
+    def truth(self, i: PropositionalInterpretation, *args):
         """Evaluate the formula."""
         return i.get(self.s, False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,8 @@ ldlf_formulas = [
     "<A ; B>ff",
     "<A*>tt",
     "<A*>ff",
-    "<<A>tt?>tt",
-    "<<A>tt?>ff",
+    "<?<A>tt>tt",
+    "<?<A>tt>ff",
     "[A & B]tt",
     "[A & B]ff",
     "[A | C]tt",
@@ -39,8 +39,8 @@ ldlf_formulas = [
     "[A ; B]ff",
     "[A*]tt",
     "[A*]ff",
-    "[<A>tt?]tt",
-    "[<A>tt?]ff",
+    "[?<A>tt]tt",
+    "[?<A>tt]ff",
 ]
 
 

--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -12,7 +12,7 @@ class ParsingCheck:
 
         :param lark: path of a lark grammar file.
         """
-        self.parser = Lark(open(lark), parser="lalr")
+        self.parser = Lark(open(lark), parser="lalr", debug=True)
 
     def precedence_check(
         self, formula: str, tokens: List[str], print_tree: bool = False

--- a/tests/test_ldlf.py
+++ b/tests/test_ldlf.py
@@ -107,49 +107,75 @@ def test_parser():
     )
 
 
-def test_truth():
-    sa, sb = "A", "B"
-    a, b = PLAtomic(sa), PLAtomic(sb)
+class TestTruth:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = LDLfParser()
+        cls.trace = [{}, {"A": True}, {"A": True}, {"A": True, "B": True}, {}]
 
-    i_ = {}
-    i_a = {"A": True}
-    i_b = {"B": True}
-    i_ab = {"A": True, "B": True}
+    def test_1(self):
+        sa, sb = "A", "B"
+        a, b = PLAtomic(sa), PLAtomic(sb)
 
-    tr_false_a_b_ab = [i_, i_a, i_b, i_ab, i_]
+        i_ = {}
+        i_a = {"A": True}
+        i_b = {"B": True}
+        i_ab = {"A": True, "B": True}
 
-    tt = LDLfLogicalTrue()
-    ff = LDLfLogicalFalse()
+        tr_false_a_b_ab = [i_, i_a, i_b, i_ab, i_]
 
-    assert tt.truth(tr_false_a_b_ab, 0)
-    assert not ff.truth(tr_false_a_b_ab, 0)
-    assert not LDLfNot(tt).truth(tr_false_a_b_ab, 0)
-    assert LDLfNot(ff).truth(tr_false_a_b_ab, 0)
-    # assert LDLfAnd([LDLfPropositional(a), LDLfPropositional(b)]).truth(
-    #     tr_false_a_b_ab, 3
-    # )
-    assert not LDLfDiamond(RegExpPropositional(PLAnd([a, b])), tt).truth(
-        tr_false_a_b_ab, 0
-    )
+        tt = LDLfLogicalTrue()
+        ff = LDLfLogicalFalse()
 
-    parser = LDLfParser()
-    trace = [{}, {"A": True}, {"A": True}, {"A": True, "B": True}, {}]
+        assert tt.truth(tr_false_a_b_ab, 0)
+        assert not ff.truth(tr_false_a_b_ab, 0)
+        assert not LDLfNot(tt).truth(tr_false_a_b_ab, 0)
+        assert LDLfNot(ff).truth(tr_false_a_b_ab, 0)
+        # assert LDLfAnd([LDLfPropositional(a), LDLfPropositional(b)]).truth(
+        #     tr_false_a_b_ab, 3
+        # )
+        assert not LDLfDiamond(RegExpPropositional(PLAnd([a, b])), tt).truth(
+            tr_false_a_b_ab, 0
+        )
 
-    formula = "<true*;A&B>tt"
-    parsed_formula = parser(formula)
-    assert parsed_formula.truth(trace, 0)
+        trace = self.trace
+        parser = self.parser
 
-    formula = "[(A+!B)*]<C>tt"
-    parsed_formula = parser(formula)
-    assert not parsed_formula.truth(trace, 1)
+        formula = "<true*;A&B>tt"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
 
-    formula = "<?(<!C>tt)><A>tt"
-    parsed_formula = parser(formula)
-    assert parsed_formula.truth(trace, 1)
+        formula = "[(A+!B)*]<C>tt"
+        parsed_formula = parser(formula)
+        assert not parsed_formula.truth(trace, 1)
 
-    formula = "<!C+A>tt"
-    parsed_formula = parser(formula)
-    assert parsed_formula.truth(trace, 1)
+        formula = "<?(<!C>tt)><A>tt"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 1)
+
+        formula = "<!C+A>tt"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 1)
+
+        formula = "<!C+A>tt"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 1)
+
+        formula = "<!A>A"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+        formula = "<!A; !B>(A & B)"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+    def test_2(self):
+        parser = self.parser
+        trace = self.trace
+
+        formula = "<true*>A&B"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
 
 
 def test_nnf():

--- a/tests/test_ldlf.py
+++ b/tests/test_ldlf.py
@@ -161,21 +161,37 @@ class TestTruth:
         parsed_formula = parser(formula)
         assert parsed_formula.truth(trace, 1)
 
-        formula = "<!A>A"
-        parsed_formula = parser(formula)
-        assert parsed_formula.truth(trace, 0)
-
-        formula = "<!A; !B>(A & B)"
-        parsed_formula = parser(formula)
-        assert parsed_formula.truth(trace, 0)
-
     def test_2(self):
         parser = self.parser
         trace = self.trace
 
-        formula = "<true*>A&B"
+        formula = "<!A>A"
         parsed_formula = parser(formula)
         assert parsed_formula.truth(trace, 0)
+
+        formula = "<!A; !B><A>(A & B)"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+        formula = "<true*>(A&B&<true>(!A&!B))"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+        formula = "[true*; B]!A"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+        formula = "[true*]!C"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 0)
+
+        formula = "!<true>A & !<true>true & <true>tt"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 4)
+
+        formula = "<true>(!A & !true & tt) & !A & !B"
+        parsed_formula = parser(formula)
+        assert parsed_formula.truth(trace, 4)
 
 
 def test_nnf():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -73,11 +73,13 @@ def test_hash_consistency_after_pickling():
 
 
 def test_QuotedFormula():
-    from flloat.parser.ltlf import LTLfParser
     from flloat.base import QuotedFormula
+    from flloat.parser.ltlf import LTLfParser
+    from flloat.ltlf import LTLfAtomic, LTLfAnd
 
-    f = LTLfParser()("!(G a & X b)")
+    f = LTLfParser()("!(G a)")
     qf = QuotedFormula(f)
+    atomf = LTLfAnd([LTLfAtomic(f), LTLfAtomic(f)])
 
     assert qf.wrapped is f
 

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -261,6 +261,3 @@ class TestParsingTree:
 
         with pytest.raises(lark.UnexpectedInput):
             self.checker.precedence_check("a|b|", list("a|b|"))
-
-        with pytest.raises(lark.UnexpectedInput):
-            self.checker.precedence_check("a|3", list("a|3"))


### PR DESCRIPTION
## Proposed changes

New parsing files to solve these issues:
- Propositional logic is now part of LDLf. Any PL sentence is a valid LDLf sentence.
- Simplified tree Transformer for LDLf.
- Each logic uses its own naming convention for atomic symbols. Classes of atomics follow the same convention as each parser.

Proposal:
- The symbol of the test operator is written on the left. See comments.

Added myself among contributors.

## Fixes
- `a`, `<a>b` and many more are now valid LDLf formulae.
- Valid atomic symbols are: `tt, ff , true, false` and all propositional symbols.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments
