### PR TITLE
get to_ldlf() working

### DIFF
--- a/flloat/ltlf.py
+++ b/flloat/ltlf.py
@@ -31,6 +31,7 @@ from flloat.ldlf import (
     LDLfAnd,
     LDLfOr,
     LDLfDiamond,
+    LDLfBox,
     LDLfEnd,
     RegExpPropositional,
     RegExpStar,
@@ -420,11 +421,8 @@ class LTLfWeakNext(LTLfUnaryOperator):
 
     def to_ldlf(self):
         """Convert the formula to LDLf."""
-        return LDLfNot(
-            LDLfDiamond(
-                RegExpPropositional(PLTrue()),
-                LDLfAnd([LDLfNot(self.f.to_ldlf()), LDLfNot(LDLfEnd())]),
-            )
+        return LDLfBox(
+            RegExpPropositional(PLTrue()), LDLfOr([self.f.to_ldlf(), LDLfEnd()])
         )
 
 
@@ -533,19 +531,17 @@ class LTLfRelease(LTLfBinaryOperator):
 
     def to_ldlf(self):
         """Convert the formula to LDLf."""
-        f1 = LDLfNot(self.formulas[0].to_ldlf())
+        f1 = self.formulas[0].to_ldlf()
         f2 = (
             LTLfRelease(self.formulas[1:]).to_ldlf()
             if len(self.formulas) > 2
-            else LDLfNot(self.formulas[1].to_ldlf())
+            else self.formulas[1].to_ldlf()
         )
-        return LDLfNot(
-            LDLfDiamond(
-                RegExpStar(
-                    RegExpSequence([RegExpTest(f1), RegExpPropositional(PLTrue())])
-                ),
-                LDLfAnd([f2, LDLfNot(LDLfEnd())]),
-            )
+        return LDLfBox(
+            RegExpStar(
+                RegExpSequence([RegExpTest(LDLfNot(f1)), RegExpPropositional(PLTrue())])
+            ),
+            LDLfOr([f2, LDLfEnd()]),
         )
 
 
@@ -607,11 +603,9 @@ class LTLfAlways(LTLfUnaryOperator):
 
     def to_ldlf(self):
         """Convert the formula to LDLf."""
-        return LDLfNot(
-            LDLfDiamond(
-                RegExpStar(RegExpPropositional(PLTrue())),
-                LDLfAnd([LDLfNot(self.f.to_ldlf()), LDLfNot(LDLfEnd())]),
-            )
+        return LDLfBox(
+            RegExpStar(RegExpPropositional(PLTrue())),
+            LDLfOr([self.f.to_ldlf(), LDLfEnd()]),
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,7 @@ class LTLfFixtures:
         "true",
         "false",
         "a -> b",
+        "a -> b -> c",
         "a <-> b",
         "G(a -> b)",
         "G(a -> F(b))",

--- a/tests/test_ldlf.py
+++ b/tests/test_ldlf.py
@@ -131,6 +131,7 @@ class TestTruth:
         assert not ff.truth(tr_false_a_b_ab, 0)
         assert not LDLfNot(tt).truth(tr_false_a_b_ab, 0)
         assert LDLfNot(ff).truth(tr_false_a_b_ab, 0)
+        assert LDLfDiamond(RegExpPropositional(a), LDLfLogicalTrue()).truth([i_a], 0)
         # assert LDLfAnd([LDLfPropositional(a), LDLfPropositional(b)]).truth(
         #     tr_false_a_b_ab, 3
         # )

--- a/tests/test_ltlf.py
+++ b/tests/test_ltlf.py
@@ -763,6 +763,13 @@ def ltlf_formula_nnf_pair(request):
     return formula_obj, nnf
 
 
+@pytest.fixture(scope="session", params=LTLfFixtures.ltlf_formulas)
+def ltlf_formula_to_ldlf_pair(request):
+    formula_obj = parser(request.param)
+    formula_ldlf = formula_obj.to_ldlf()
+    return formula_obj, formula_ldlf
+
+
 @given(propositional_words(["a", "b", "c"], min_size=0, max_size=5))
 def test_nnf_equivalence(ltlf_formula_nnf_pair, word):
     """Test that a formula is equivalent to its NNF form."""
@@ -781,6 +788,13 @@ def test_persistence_is_equivalent_to_response_on_nonempty_words(word):
     formula_1 = LTLfAlways(LTLfEventually(LTLfAtomic("a")))
     formula_2 = LTLfEventually(LTLfAlways(LTLfAtomic("a")))
     assert formula_1.truth(word, 0) == formula_2.truth(word, 0)
+
+
+@given(propositional_words(["a", "b", "c"], min_size=1, max_size=5))
+def test_ltlf_to_ldlf_equivalence(ltlf_formula_to_ldlf_pair, word):
+    """Test that an LTLf formula is equivalent to its LDLf form."""
+    formula_ltlf, formula_ldlf = ltlf_formula_to_ldlf_pair
+    assert formula_ltlf.truth(word, 0) == formula_ldlf.truth(word, 0)
 
 
 def test_persistence_and_response_on_empty_words():


### PR DESCRIPTION
## Proposed changes

- get the `to_ldlf()` method working for all formulas except for LTLfEnd which is not supported yet.

## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [x] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
